### PR TITLE
NPOI.XWPF.UserModel.XWPFParagraph扩展ReplaceText和SearchText方法

### DIFF
--- a/src/NPOI.OOXML/XWPF/Usermodel/XWPFParagraph.cs
+++ b/src/NPOI.OOXML/XWPF/Usermodel/XWPFParagraph.cs
@@ -1253,11 +1253,11 @@ namespace NPOI.XWPF.UserModel
         }
 
         /// <summary>
-        /// 段落文本替换
+        /// Replace for the text searched
         /// </summary>
-        /// <param name="oldText">旧文本</param>
-        /// <param name="newText">新文本</param>
-        /// <param name="replaceAll">替换所有匹配项</param>
+        /// <param name="oldText">old text</param>
+        /// <param name="newText">new text</param>
+        /// <param name="replaceAll">Replace all for the text searched</param>
         public void ReplaceText(string oldText, string newText, bool replaceAll = false)
         {
             var paragraph = this;
@@ -1366,9 +1366,9 @@ namespace NPOI.XWPF.UserModel
         }
 
         /// <summary>
-        /// 搜索文本
+        /// search for the text searched
         /// </summary>
-        /// <param name="text">文本</param>
+        /// <param name="text">search</param>
         /// <returns></returns>
         public TextSegment SearchText(string text)
         {
@@ -1381,29 +1381,23 @@ namespace NPOI.XWPF.UserModel
 
             var endChar = text.Last();
 
-            // 起始run索引
             var beginRunIndex = -1;
 
-            // 起始Char索引
             var beginCharIndex = -1;
 
-            // 结束run索引
             var endRunIndex = -1;
 
-            // 结束Char索引
             var endCharIndex = -1;
 
             var runs = Runs;
 
             for (int i = 0; i < runs.Count; i++)
             {
-                // 查找起始索引
                 var beginIndex = runs[i].Text.IndexOf(beginChar);
 
-                // 如果存在起始索引，该run可能为起始run
+                // find beginRunIndex and beginCharIndex
                 if (beginIndex > -1)
                 {
-                    // 如果不是最后一个run，那么，该run包含text开始片段
                     if (i < runs.Count - 1 && text.StartsWith(runs[i].Text.Substring(beginIndex, Math.Min(text.Length, runs[i].Text.Length - beginIndex))))
                     {
                         beginRunIndex = i;
@@ -1411,7 +1405,6 @@ namespace NPOI.XWPF.UserModel
                         beginCharIndex = beginIndex;
                     }
 
-                    // 如果是最后一个run，那么，该run包含text
                     if (i == runs.Count - 1 && runs[i].Text.Contains(text))
                     {
                         beginRunIndex = i;
@@ -1420,18 +1413,15 @@ namespace NPOI.XWPF.UserModel
                     }
                 }
 
-                // 查找结束索引
                 var endIndex = runs[i].Text.IndexOf(endChar);
 
-                // 如果存在结束索引，该run可能为结束run
+                // find beginRunIndex and beginCharIndex
                 if (endIndex > -1)
                 {
                     var runTextStard = runs[i].Text.Substring(0, endIndex + 1);
 
-                    // text结束片段
                     var textEnd = runTextStard.Substring(endIndex + 1 - Math.Min(text.Length, runTextStard.Length));
 
-                    // 如果不是第一个run，那么，该run包含text结束片段
                     if (i > 0 && text.EndsWith(textEnd))
                     {
                         endRunIndex = i;
@@ -1439,7 +1429,6 @@ namespace NPOI.XWPF.UserModel
                         endCharIndex = endIndex;
                     }
 
-                    // 如果是第一个run，那么，该run包含text
                     if (i == 0 && runs[i].Text.Contains(text))
                     {
                         endRunIndex = i;
@@ -1448,7 +1437,6 @@ namespace NPOI.XWPF.UserModel
                     }
                 }
 
-                // 已找到run索引，则退出循环
                 if (beginRunIndex >= 0 && endRunIndex >= beginRunIndex)
                 {
                     break;

--- a/src/NPOI.OOXML/XWPF/Usermodel/XWPFParagraph.cs
+++ b/src/NPOI.OOXML/XWPF/Usermodel/XWPFParagraph.cs
@@ -17,19 +17,21 @@
 namespace NPOI.XWPF.UserModel
 {
     using System;
-    using System.Collections.Generic;
-    using NPOI.OpenXmlFormats.Wordprocessing;
-    using System.Text;
-    using NPOI.Util;
     using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using NPOI.OpenXmlFormats.Wordprocessing;
+    using NPOI.Util;
     using NPOI.WP.UserModel;
+
     /**
-     * <p>A Paragraph within a Document, Table, Header etc.</p> 
-     * 
-     * <p>A paragraph has a lot of styling information, but the
-     *  actual text (possibly along with more styling) is held on
-     *  the child {@link XWPFRun}s.</p>
-     */
+* <p>A Paragraph within a Document, Table, Header etc.</p> 
+* 
+* <p>A paragraph has a lot of styling information, but the
+*  actual text (possibly along with more styling) is held on
+*  the child {@link XWPFRun}s.</p>
+*/
     public class XWPFParagraph : IBodyElement, IRunBody, ISDTContents, IParagraph
     {
         private CT_P paragraph;
@@ -1249,6 +1251,42 @@ namespace NPOI.XWPF.UserModel
                 }
             }
         }
+
+        /// <summary>
+        /// 段落文本替换
+        /// </summary>
+        /// <param name="oldText">旧文本</param>
+        /// <param name="newText">新文本</param>
+        /// <param name="replaceAll">替换所有匹配项</param>
+        public void ReplaceText(string oldText, string newText, bool replaceAll = false)
+        {
+            var paragraph = this;
+
+            var segment = paragraph.SearchText(oldText);
+
+            if (segment == null)
+            {
+                return;
+            }
+
+            paragraph.Runs.ElementAt(segment.BeginRun).ReplaceText(paragraph.Runs.ElementAt(segment.BeginRun).Text.Substring(segment.BeginChar), newText);
+
+            if (segment.EndRun > segment.BeginRun)
+            {
+                paragraph.Runs.ElementAt(segment.EndRun).ReplaceText(paragraph.Runs.ElementAt(segment.EndRun).Text.Substring(0, segment.EndChar + 1), string.Empty);
+
+                for (int i = segment.BeginRun + 1; i < segment.EndRun; i++)
+                {
+                    paragraph.Runs.ElementAt(i).ReplaceText(paragraph.Runs.ElementAt(i).Text, string.Empty);
+                }
+            }
+
+            if (replaceAll)
+            {
+                ReplaceText(oldText, newText, replaceAll);
+            }
+        }
+
         /// <summary>
         /// this methods parse the paragraph and search for the string searched. 
         /// If it finds the string, it will return true and the position of the String will be saved in the parameter startPos.
@@ -1325,6 +1363,112 @@ namespace NPOI.XWPF.UserModel
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// 搜索文本
+        /// </summary>
+        /// <param name="text">文本</param>
+        /// <returns></returns>
+        public TextSegment SearchText(string text)
+        {
+            if (string.IsNullOrEmpty(text) || Text?.Contains(text) != true)
+            {
+                return null;
+            }
+
+            var beginChar = text.First();
+
+            var endChar = text.Last();
+
+            // 起始run索引
+            var beginRunIndex = -1;
+
+            // 起始Char索引
+            var beginCharIndex = -1;
+
+            // 结束run索引
+            var endRunIndex = -1;
+
+            // 结束Char索引
+            var endCharIndex = -1;
+
+            var runs = Runs;
+
+            for (int i = 0; i < runs.Count; i++)
+            {
+                // 查找起始索引
+                var beginIndex = runs[i].Text.IndexOf(beginChar);
+
+                // 如果存在起始索引，该run可能为起始run
+                if (beginIndex > -1)
+                {
+                    // 如果不是最后一个run，那么，该run包含text开始片段
+                    if (i < runs.Count - 1 && text.StartsWith(runs[i].Text.Substring(beginIndex, Math.Min(text.Length, runs[i].Text.Length - beginIndex))))
+                    {
+                        beginRunIndex = i;
+
+                        beginCharIndex = beginIndex;
+                    }
+
+                    // 如果是最后一个run，那么，该run包含text
+                    if (i == runs.Count - 1 && runs[i].Text.Contains(text))
+                    {
+                        beginRunIndex = i;
+
+                        beginCharIndex = beginIndex;
+                    }
+                }
+
+                // 查找结束索引
+                var endIndex = runs[i].Text.IndexOf(endChar);
+
+                // 如果存在结束索引，该run可能为结束run
+                if (endIndex > -1)
+                {
+                    var runTextStard = runs[i].Text.Substring(0, endIndex + 1);
+
+                    // text结束片段
+                    var textEnd = runTextStard.Substring(endIndex + 1 - Math.Min(text.Length, runTextStard.Length));
+
+                    // 如果不是第一个run，那么，该run包含text结束片段
+                    if (i > 0 && text.EndsWith(textEnd))
+                    {
+                        endRunIndex = i;
+
+                        endCharIndex = endIndex;
+                    }
+
+                    // 如果是第一个run，那么，该run包含text
+                    if (i == 0 && runs[i].Text.Contains(text))
+                    {
+                        endRunIndex = i;
+
+                        endCharIndex = endIndex;
+                    }
+                }
+
+                // 已找到run索引，则退出循环
+                if (beginRunIndex >= 0 && endRunIndex >= beginRunIndex)
+                {
+                    break;
+                }
+            }
+
+            var segment = default(TextSegment);
+
+            if (beginRunIndex > -1 && endRunIndex >= beginRunIndex)
+            {
+                segment = new TextSegment
+                {
+                    BeginRun = beginRunIndex,
+                    BeginChar = beginCharIndex,
+                    EndRun = endRunIndex,
+                    EndChar = endCharIndex
+                };
+            }
+
+            return segment;
         }
 
         /**


### PR DESCRIPTION
为NPOI.XWPF.UserModel.XWPFParagraph扩展ReplaceText和SearchText方法，支持word文档段落关键字的替换，原ReplaceText方法在操作word模板的关键字替换时出现空引用异常。