### PR TITLE
Add information about new dependencies since 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Install-Package DotNetCore.NPOI
 
 ### How can it work on Linux?
 
-On Linux, you need install `libgdiplus`.
+On Linux, you need install `libgdiplus`. Since 1.2.0 libdl is also required.
 
 - Ubuntu 16.04 and above:
-	- apt-get install libgdiplus
+	- apt-get install libgdiplus libc6-dev
 	- cd /usr/lib
 	- ln -s libgdiplus.so gdiplus.dll
 - Fedora 23 and above:
@@ -44,6 +44,12 @@ On Linux, you need install `libgdiplus`.
 
     RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
     RUN apk --update add libgdiplus
+    ```
+    - Debian
+    ```
+    FROM microsoft/dotnet:2.1-aspnetcore-runtime
+    RUN apt-get update && apt-get install -y libgdiplus libc6-dev && ln -s /usr/lib/libgdiplus.so /usr/lib/gdiplus.dll
+    ...
     ```
 
 ### Getting Started


### PR DESCRIPTION
Hey,

i updated to 1.2.0 recently and could not use the lib like before. An exception was thrown:

System.TypeInitializationException: The type initializer for 'Gdip' threw an exception. ---> System.DllNotFoundException: Unable to load shared library 'libdl' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: liblibdl: cannot open shared object file: No such file or directory
--

After some research i found out that libdl is required which is not installed per default in the Debian based ASP.Net Core 2.1 container. As fix an additional package has to be installed: libc6-dev.