### PR TITLE
Fix potential null reference exceptions, bump zip lib version

### DIFF
--- a/src/NPOI.OOXML/NPOI.OOXML.csproj
+++ b/src/NPOI.OOXML/NPOI.OOXML.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <PackageId>DotNetCore.NPOI</PackageId>   
+    <PackageId>DotNetCore.NPOI</PackageId>
+    <Version>1.2.1</Version>  
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NPOI.OOXML/SS/Converter/ExcelToHtmlConverter.cs
+++ b/src/NPOI.OOXML/SS/Converter/ExcelToHtmlConverter.cs
@@ -674,8 +674,6 @@ namespace NPOI.SS.Converter
             {
                 style.Append("white-space: pre-wrap; ");
                 ExcelToHtmlUtils.AppendAlign(style, cellStyle.Alignment);
-                StylesTable st = ((XSSFWorkbook)workbook).GetStylesSource();
-                ThemesTable tt = st.GetTheme();
                 if (cellStyle.FillPattern == FillPattern.NoFill)
                 {
                     // no fill
@@ -741,7 +739,7 @@ namespace NPOI.SS.Converter
 
             if (workbook is HSSFWorkbook)
             {
-                HSSFColor color = ((HSSFWorkbook)workbook).GetCustomPalette().GetColor(borderColor);
+                HSSFColor color = ((HSSFWorkbook)workbook).GetCustomPalette()?.GetColor(borderColor);
                 if (color != null)
                 {
                     borderStyle.Append(' ');
@@ -758,7 +756,7 @@ namespace NPOI.SS.Converter
                 }
                 else
                 {
-                    XSSFColor color = ((XSSFWorkbook)workbook).GetStylesSource().GetTheme().GetThemeColor(borderColor);
+                    XSSFColor color = ((XSSFWorkbook)workbook)?.GetStylesSource()?.GetTheme()?.GetThemeColor(borderColor);
                     if (color != null)
                     {
                         borderStyle.Append(' ');
@@ -785,7 +783,7 @@ namespace NPOI.SS.Converter
 
             if (workbook is HSSFWorkbook)
             {
-                HSSFColor fontColor = ((HSSFWorkbook)workbook).GetCustomPalette().GetColor(font.Color);
+                HSSFColor fontColor = ((HSSFWorkbook)workbook).GetCustomPalette()?.GetColor(font.Color);
                 if (fontColor != null)
                     style.AppendFormat("color:{0}; " ,ExcelToHtmlUtils.GetColor(fontColor) );
             }

--- a/src/NPOI/NPOI.csproj
+++ b/src/NPOI/NPOI.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.0.0-rc1" />
+    <PackageReference Include="SharpZipLib" Version="1.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
After testing the ExcelToHtmlConverter, found a few spots where a NullReferenceException could potentially occur and addressed those issues. Also bumped the zip lib version as requested in https://github.com/dotnetcore/NPOI/issues/86 and https://github.com/dotnetcore/NPOI/issues/75. Bumped the package version as well due to these changes. Happy to make any adjustments to this PR as necessary.