### PR TITLE
Styles.xml: fix default patternType when attribute is missing

### DIFF
--- a/src/NPOI.OpenXmlFormats/Spreadsheet/Styles/CT_PatternFill.cs
+++ b/src/NPOI.OpenXmlFormats/Spreadsheet/Styles/CT_PatternFill.cs
@@ -50,7 +50,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_PatternFill ctObj = new CT_PatternFill();
-            if (node.Attributes["patternType"] != null)
+            if (node.Attributes["patternType"] == null)
+                ctObj.patternType = ST_PatternType.solid;
+            else
                 ctObj.patternType = (ST_PatternType)Enum.Parse(typeof(ST_PatternType), node.Attributes["patternType"].Value);
             foreach (XmlNode childNode in node.ChildNodes)
             {


### PR DESCRIPTION
When reading `styles.xml` the parser sets `patternStyle` to `none` if the attribute it missing, however the default value is `solid`.
```
<patternFill>
    <rgb="FFFFC000"/>
</patternFill>
```
Above snippet should be equivalent to the snippet below.
```
<patternFill patternStyle="solid">
    <rgb="FFFFC000"/>
</patternFill>
```